### PR TITLE
Bugfix/grits

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -416,21 +416,23 @@ def print_metrics_summary(metrics_summary):
     averaged over all samples.
     """
 
-    print('-' * 100)
-    for table_type in ['simple', 'complex', 'all']:
+    print("-" * 100)
+    for table_type in ["simple", "complex", "all"]:
         metrics = metrics_summary[table_type]
-        print("Results on {} tables ({} total):".format(table_type, metrics['num_tables']))
-        print("      Accuracy_Con: {:.4f}".format(metrics['acc_con']))
-        print("         GriTS_Top: {:.4f}".format(metrics['grits_top']))
-        print("         GriTS_Con: {:.4f}".format(metrics['grits_con']))
-        print("         GriTS_Loc: {:.4f}".format(metrics['grits_loc']))
-        if 'grits_rawloc' in metrics:
-            print("      GriTS_RawLoc: {:.4f}".format(metrics['grits_rawloc']))
-        if 'dar_con_original' in metrics:
-            print("DAR_Con (original): {:.4f}".format(metrics['dar_con_original']))
-        if 'dar_con' in metrics:
-            print("           DAR_Con: {:.4f}".format(metrics['dar_con']))
-        print('-' * 50)
+        print(f'Results on {table_type} tables ({metrics.get("num_tables", 0)} total):')
+        print("      Accuracy_Con: {:.4f}".format(metrics.get("acc_con", 0)))
+        print("         GriTS_Top: {:.4f}".format(metrics.get("grits_top", 0)))
+        print("         GriTS_Con: {:.4f}".format(metrics.get("grits_con", 0)))
+        print("         GriTS_Loc: {:.4f}".format(metrics.get("grits_loc", 0)))
+        if "grits_rawloc" in metrics:
+            print("      GriTS_RawLoc: {:.4f}".format(metrics.get("grits_rawloc", 0)))
+        if "dar_con_original" in metrics:
+            print(
+                "DAR_Con (original): {:.4f}".format(metrics.get("dar_con_original", 0))
+            )
+        if "dar_con" in metrics:
+            print("           DAR_Con: {:.4f}".format(metrics.get("dar_con", 0)))
+        print("-" * 50)
 
 
 def eval_tsr(args, model, dataset_test, device):

--- a/src/grits.py
+++ b/src/grits.py
@@ -351,24 +351,34 @@ def grits_top(true_relative_span_grid, pred_relative_span_grid):
     relative to the current grid cell location, in grid coordinate units.
     Note that for a non-spanning cell this will always be [0, 0, 1, 1].
     """
-    return factored_2dmss(true_relative_span_grid,
-                          pred_relative_span_grid,
-                          reward_function=iou)
+    try:
+        return factored_2dmss(true_relative_span_grid,
+                            pred_relative_span_grid,
+                            reward_function=iou)
+    except Exception as e:
+        return 0, 0, 0, 0
+
 
 
 def grits_loc(true_bbox_grid, pred_bbox_grid):
     """
     Compute GriTS_Loc given two matrices of cell bounding boxes.
     """
-    return factored_2dmss(true_bbox_grid,
-                          pred_bbox_grid,
-                          reward_function=iou)
+    try:
+        return factored_2dmss(true_bbox_grid,
+                            pred_bbox_grid,
+                            reward_function=iou)
+    except Exception as e:
+        return 0, 0, 0, 0
 
 
 def grits_con(true_text_grid, pred_text_grid):
     """
     Compute GriTS_Con given two matrices of cell text strings.
     """
-    return factored_2dmss(true_text_grid,
-                          pred_text_grid,
-                          reward_function=lcs_similarity)
+    try:
+        return factored_2dmss(true_text_grid,
+                            pred_text_grid,
+                            reward_function=lcs_similarity)
+    except Exception as e:
+        return 0, 0, 0, 0


### PR DESCRIPTION
## What

Minor bugfixes when evaluating GriTS

## Why

- Was getting `KeyError` when evaluating GriTS only on a single `table_type`, i.e., either simple or complex
- Return 0s if computing any of the GriTS scores fails so that the execution of the program is not halted

## How

- Used `dict.get()` method to return a default value of 0 is the Key is not found, i.e., if the `table_type` is not present
- Used exception handling during computing GriTS