### PR TITLE
Removed redundant backbone argument

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,9 +32,6 @@ def get_args():
     parser.add_argument('--config_file',
                         required=True,
                         help="Filepath to the config containing the args")
-    parser.add_argument('--backbone',
-                        default='resnet18',
-                        help="Backbone for the model")
     parser.add_argument(
         '--data_type',
         choices=['detection', 'structure'],


### PR DESCRIPTION
`cmd_args` overrides `config_args`; hence, setting the value of backbone in the config file isn't sufficient for changing the backbone network. The default value of `backbone` is always overridden as 'resnet18' due to argparse's default parameter value. This might go unnoticed until training is complete and inference starts and hence should be handled before initiating any experiment.